### PR TITLE
Preserve affiliations

### DIFF
--- a/src/rocrate_upload/authors.py
+++ b/src/rocrate_upload/authors.py
@@ -32,7 +32,7 @@ def get_author_details(person: Person) -> dict:
 
     affiliation = person.get("affiliation", None)
     if affiliation:
-        affiliation = get_affiliation_name_or_id(affiliation)
+        affiliation = get_affiliation_name(affiliation)
 
     return {"name": name, "orcid": orcid, "affiliation": affiliation}
 
@@ -72,7 +72,7 @@ def get_formatted_author_name(person: Person) -> str:
     return name
 
 
-def get_affiliation_name_or_id(organization: ContextEntity | str) -> str:
+def get_affiliation_name(organization: ContextEntity | str) -> str:
     # if it's free text, return as-is
     if type(organization) == str:
         return organization
@@ -80,14 +80,8 @@ def get_affiliation_name_or_id(organization: ContextEntity | str) -> str:
     # otherwise, we should have a ContextEntity object
     assert isinstance(organization, ContextEntity)
 
-    # use the ROR if there is one
-    id = organization["@id"]
-    ror = get_ror_id_or_none(id)
-    if ror:
-        return ror
-
-    # if no ROR, use the name, or the id as a last resort
-    id = id.lstrip("#")
+    # get the organisation name, or fall back on @id
+    id = organization["@id"].lstrip("#")
     name = organization.get("name", id)
     return name
 

--- a/src/rocrate_upload/authors.py
+++ b/src/rocrate_upload/authors.py
@@ -4,12 +4,14 @@ import re
 import logging
 
 from rocrate.model.person import Person
+from rocrate.model.contextentity import ContextEntity
 from zenodo_client import Creator
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 ORCID_REGEX = r"https:\/\/orcid\.org\/(?P<id>([0-9]{4}-){3}[0-9]{3}[0-9X])"
+ROR_REGEX = r"https:\/\/ror\.org\/(?P<id>0[a-hj-km-np-tv-z|0-9]{6}[0-9]{2})"
 
 
 def build_zenodo_creator_list(authors: list[Person] | Person) -> list[Creator]:
@@ -24,15 +26,15 @@ def get_author_details(person: Person) -> dict:
     """Collects details from a Person entity and returns them using Creator fields"""
     # check if @id is an ORCID
     id = person["@id"]
-    orcid_id = get_orcid_id_or_none(id)
+    orcid = get_orcid_id_or_none(id)
 
     name = get_formatted_author_name(person)
 
     affiliation = person.get("affiliation", None)
     if affiliation:
-        affiliation = str(affiliation)
+        affiliation = get_affiliation_name_or_id(affiliation)
 
-    return {"name": name, "orcid": orcid_id, "affiliation": affiliation}
+    return {"name": name, "orcid": orcid, "affiliation": affiliation}
 
 
 def get_formatted_author_name(person: Person) -> str:
@@ -70,8 +72,36 @@ def get_formatted_author_name(person: Person) -> str:
     return name
 
 
+def get_affiliation_name_or_id(organization: ContextEntity | str) -> str:
+    # if it's free text, return as-is
+    if type(organization) == str:
+        return organization
+
+    # otherwise, we should have a ContextEntity object
+    assert isinstance(organization, ContextEntity)
+
+    # use the ROR if there is one
+    id = organization["@id"]
+    ror = get_ror_id_or_none(id)
+    if ror:
+        return ror
+
+    # if no ROR, use the name, or the id as a last resort
+    id = id.lstrip("#")
+    name = organization.get("name", id)
+    return name
+
+
 def get_orcid_id_or_none(str: str) -> str | None:
     match = re.match(ORCID_REGEX, str)
+    if match:
+        return match.group("id")
+    else:
+        return None
+
+
+def get_ror_id_or_none(str: str) -> str | None:
+    match = re.match(ROR_REGEX, str)
     if match:
         return match.group("id")
     else:

--- a/src/rocrate_upload/upload.py
+++ b/src/rocrate_upload/upload.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 import json
 
@@ -57,7 +58,7 @@ def ensure_crate_zipped(crate: ROCrate) -> str:
     return zipped
 
 
-def upload_crate_to_zenodo(crate_zip_path: str, metadata: Metadata):
+def upload_crate_to_zenodo(crate_zip_path: str, metadata: Metadata) -> Any:
     """Upload a zipped crate and its metadata to Zenodo.
 
     It's recommended to keep sandbox=True until ready for production use."""

--- a/test/test_author_utils.py
+++ b/test/test_author_utils.py
@@ -1,6 +1,48 @@
 import pytest
 
-from rocrate_upload.authors import get_orcid_id_or_none, get_author_details
+from rocrate.model.contextentity import ContextEntity
+from rocrate_upload.authors import (
+    get_orcid_id_or_none,
+    get_ror_id_or_none,
+    get_affiliation_name_or_id,
+)
+
+organizations = {
+    # organization with id as ROR
+    "id-ror": {
+        "identifier": "https://ror.org/0abcdef12",
+        "properties": {
+            "name": "ROR Organization",
+        },
+    },
+    # organization with id as URI
+    "id-uri": {
+        "identifier": "https://example.org",
+        "properties": {
+            "name": "URI Organization",
+        },
+    },
+    # organization with id as local identifier
+    "id-local": {
+        "identifier": "#local_organization",
+        "properties": {
+            "name": "Local Organization",
+        },
+    },
+    # organization with id as a name, and no other info
+    "id-name": {"identifier": "Named Organization"},
+    # organization with id as blank node identifier
+    "id-blank-node": {
+        "identifier": "_:blank_organization",
+    },
+    # organization with international characters in their name
+    "name-intl-chars": {
+        "identifier": "Ãệïøù Organization",
+        "properties": {
+            "name": "Ãệïøù Organization",
+        },
+    },
+}
 
 
 @pytest.mark.parametrize(
@@ -17,4 +59,55 @@ def test_get_orcid_id(input, expected):
     result = get_orcid_id_or_none(input)
 
     # Assert
+    assert expected == result
+
+
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        ("https://ror.org/02mhbdp94", "02mhbdp94"),
+        ("02mhbdp94", None),
+        ("not an ROR", None),
+    ],
+)
+def test_get_ror_id(input, expected):
+    # Act
+    result = get_ror_id_or_none(input)
+
+    # Assert
+    assert expected == result
+
+
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        ("https://ror.org/02mhbdp94", "02mhbdp94"),
+        ("02mhbdp94", None),
+        ("Test University", None),
+    ],
+)
+def test_get_ror_id(input, expected):
+    # Act
+    result = get_ror_id_or_none(input)
+
+    # Assert
+    assert expected == result
+
+
+@pytest.mark.parametrize(
+    "org_key, expected",
+    [
+        ("id-ror", "0abcdef12"),
+        ("id-uri", "URI Organization"),
+        ("id-local", "Local Organization"),
+        ("id-name", "Named Organization"),
+        ("name-intl-chars", "Ãệïøù Organization"),
+    ],
+)
+def test_get_formatted_author_name(org_key, expected):
+    org_dict = organizations[org_key]
+    org = ContextEntity(None, **org_dict)
+
+    result = get_affiliation_name_or_id(org)
+
     assert expected == result

--- a/test/test_author_utils.py
+++ b/test/test_author_utils.py
@@ -4,7 +4,7 @@ from rocrate.model.contextentity import ContextEntity
 from rocrate_upload.authors import (
     get_orcid_id_or_none,
     get_ror_id_or_none,
-    get_affiliation_name_or_id,
+    get_affiliation_name,
 )
 
 organizations = {
@@ -79,25 +79,9 @@ def test_get_ror_id(input, expected):
 
 
 @pytest.mark.parametrize(
-    "input, expected",
-    [
-        ("https://ror.org/02mhbdp94", "02mhbdp94"),
-        ("02mhbdp94", None),
-        ("Test University", None),
-    ],
-)
-def test_get_ror_id(input, expected):
-    # Act
-    result = get_ror_id_or_none(input)
-
-    # Assert
-    assert expected == result
-
-
-@pytest.mark.parametrize(
     "org_key, expected",
     [
-        ("id-ror", "0abcdef12"),
+        ("id-ror", "ROR Organization"),
         ("id-uri", "URI Organization"),
         ("id-local", "Local Organization"),
         ("id-name", "Named Organization"),
@@ -108,6 +92,6 @@ def test_get_formatted_author_name(org_key, expected):
     org_dict = organizations[org_key]
     org = ContextEntity(None, **org_dict)
 
-    result = get_affiliation_name_or_id(org)
+    result = get_affiliation_name(org)
 
     assert expected == result

--- a/test/test_upload.py
+++ b/test/test_upload.py
@@ -22,7 +22,7 @@ class TestUpload(TestCase):
             "creators": [
                 {
                     "name": "Smith, Jane",
-                    "affiliation": "<https://ror.org/0abcdef00 Organization>",
+                    "affiliation": "0abcdef00",
                     "orcid": "0000-0000-0000-0000",
                     "gnd": None,
                 }

--- a/test/test_upload.py
+++ b/test/test_upload.py
@@ -22,7 +22,7 @@ class TestUpload(TestCase):
             "creators": [
                 {
                     "name": "Smith, Jane",
-                    "affiliation": "0abcdef00",
+                    "affiliation": "Example University",
                     "orcid": "0000-0000-0000-0000",
                     "gnd": None,
                 }


### PR DESCRIPTION
Fixes #3.

While you can search for an ROR in the Zenodo web UI, you can't use an ROR in the API payload, which is a shame.