### PR TITLE
Preserve license

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ black
 pytest
 pytest-cov
 mypy
+types-requests

--- a/src/rocrate_upload/authors.py
+++ b/src/rocrate_upload/authors.py
@@ -24,6 +24,11 @@ def build_zenodo_creator_list(authors: list[Person] | Person) -> list[Creator]:
 
 def get_author_details(person: Person) -> dict:
     """Collects details from a Person entity and returns them using Creator fields"""
+    if type(person) == str:
+        if "," not in person:
+            person += ","
+        return {"name": person}
+
     # check if @id is an ORCID
     id = person["@id"]
     orcid = get_orcid_id_or_none(id)

--- a/src/rocrate_upload/upload.py
+++ b/src/rocrate_upload/upload.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 SPDX_URL_PATTERN = r"^https?:\/\/spdx.org\/licenses\/(?P<id>[-_.a-zA-Z0-9]+\+?)$"
-SPDX_ID_PATTERN = r"^(?P<id>[-_.a-zA-Z0-9]+\+?)$"
+# SPDX_ID_PATTERN = r"^(?P<id>[-_.a-zA-Z0-9]+\+?)$"
 
 
 def build_zenodo_metadata_from_crate(crate: ROCrate) -> Metadata:
@@ -70,83 +70,32 @@ def build_zenodo_metadata_from_crate(crate: ROCrate) -> Metadata:
 
 
 def get_license(license: str | ContextEntity) -> str | None:
-    """Search the Zenodo license list and return the ID of the best match"""
+    """Extract the license SPDX ID, URI, or name, in order of preference"""
     if not license:
         return None
 
     # first, look at @id
     if type(license) == ContextEntity:
-        id = license["@id"]
+        id = license["@id"].lstrip("#")
         name = license.get("name", None)
     else:
         id = license
-        if " " in license:
-            name = license
-        else:
-            name = None
+        name = None
 
-    # if @id matches SPDX ID or URL patterns, extract the SPDX identifier
-    # otherwise, try and use a name
-    using_spdx = False
-    using_name = False
+    # if @id matches SPDX URI patterns, extract the SPDX identifier and return that
     match = re.match(SPDX_URL_PATTERN, id)
-    if not match:
-        match = re.match(SPDX_ID_PATTERN, id)
     if match:
-        using_spdx = True  # try to match exactly
         id = match.group("id")
         if id.endswith(".html") or id.endswith(".json"):
             id = id[:-5]
+        id = id.lower()
+        return id
+    elif " " in id or "http" in id:
+        # we have a name or a URI, return that
+        return id
     else:
-        using_name = True if name else False
-
-    search_term = name if using_name else id
-    # search Zenodo database for a matching license
-    # this is quite a forgiving search so imperfect matches are possible
-    # assume the first result is the best
-    logger.debug(
-        f'Searching Zenodo license list for "{search_term}". Using SPDX: {using_spdx}. Using name: {using_name}.'
-    )
-    if using_spdx:
-        fields = ["id"]
-    elif using_name:
-        fields = ["title"]
-    else:
-        fields = ["id", "title", "props"]
-    query = {"query_string": {"query": {search_term}, "fields": fields}}
-
-    try:
-        r = requests.get(
-            f"https://sandbox.zenodo.org/api/licenses",
-            params={"q": search_term, "size": 1, "sort": "bestmatch"},
-        )
-        r.raise_for_status()
-    except requests.exceptions.HTTPError as e:
-        if e.response.status_code == 429:
-            raise RuntimeError(
-                "Made too many requests to Zenodo API. Please wait a while and try again."
-            )
-        raise ValueError(
-            f'Zenodo returned an error when searching for license "{search_term}": {r.json()}'
-        )
-
-    try:
-        matched_license = r.json()["hits"]["hits"][0]
-    except IndexError:
-        raise ValueError(f'No matching license found for id "{id}"')
-
-    if using_spdx and matched_license["id"] != id.lower():
-        raise ValueError(
-            f'Zenodo search returned license {matched_license["id"]}, which does not match SPDX id {id}'
-        )
-    matched_license_name = matched_license["title"]["en"]
-    if using_name and matched_license_name.lower() != name.lower():
-        raise ValueError(
-            f"Zenodo search returned license {matched_license_name}, which does not match name {name}"
-        )
-
-    logger.debug(f"Found matching license: {matched_license_name}")
-    return matched_license["id"]
+        # otherwise, try and use a name, but fall back on id
+        return name if name else id
 
 
 def ensure_crate_zipped(crate: ROCrate) -> str:

--- a/src/rocrate_upload/upload.py
+++ b/src/rocrate_upload/upload.py
@@ -82,6 +82,8 @@ def get_license(license: str | ContextEntity) -> str | None:
         id = license
         if " " in license:
             name = license
+        else:
+            name = None
 
     # if @id matches SPDX ID or URL patterns, extract the SPDX identifier
     # otherwise, try and use a name

--- a/src/rocrate_upload/upload.py
+++ b/src/rocrate_upload/upload.py
@@ -105,12 +105,12 @@ def get_license(license: str | ContextEntity) -> str | None:
     logger.debug(
         f'Searching Zenodo license list for "{search_term}". Using SPDX: {using_spdx}. Using name: {using_name}.'
     )
-    # if using_spdx:
-    #     fields = ["id"]
-    # elif using_name:
-    #     fields = ["title"]
-    # else:
-    #     fields = ["id", "title", "props"]
+    if using_spdx:
+        fields = ["id"]
+    elif using_name:
+        fields = ["title"]
+    else:
+        fields = ["id", "title", "props"]
     query = {"query_string": {"query": {search_term}, "fields": fields}}
 
     try:

--- a/test/test_data/licenses.json
+++ b/test/test_data/licenses.json
@@ -1,0 +1,285 @@
+{
+  "licenses": [
+    {
+      "reference": "https://spdx.org/licenses/0BSD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/0BSD.json",
+      "referenceNumber": 537,
+      "name": "BSD Zero Clause License",
+      "licenseId": "0BSD",
+      "seeAlso": [
+        "http://landley.net/toybox/license.html",
+        "https://opensource.org/licenses/0BSD"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/AFL-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AFL-3.0.json",
+      "referenceNumber": 369,
+      "name": "Academic Free License v3.0",
+      "licenseId": "AFL-3.0",
+      "seeAlso": [
+        "http://www.rosenlaw.com/AFL3.0.htm",
+        "https://opensource.org/licenses/afl-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Apache-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Apache-2.0.json",
+      "referenceNumber": 564,
+      "name": "Apache License 2.0",
+      "licenseId": "Apache-2.0",
+      "seeAlso": [
+        "https://www.apache.org/licenses/LICENSE-2.0",
+        "https://opensource.org/licenses/Apache-2.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause.json",
+      "referenceNumber": 216,
+      "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+      "licenseId": "BSD-3-Clause",
+      "seeAlso": [
+        "https://opensource.org/licenses/BSD-3-Clause",
+        "https://www.eclipse.org/org/documents/edl-v10.php"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-Attribution.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Attribution.json",
+      "referenceNumber": 14,
+      "name": "BSD with attribution",
+      "licenseId": "BSD-3-Clause-Attribution",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/BSD_with_Attribution"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-4.0.json",
+      "referenceNumber": 265,
+      "name": "Creative Commons Attribution 4.0 International",
+      "licenseId": "CC-BY-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/4.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-4.0.json",
+      "referenceNumber": 188,
+      "name": "Creative Commons Attribution Non Commercial 4.0 International",
+      "licenseId": "CC-BY-NC-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc/4.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-4.0.json",
+      "referenceNumber": 296,
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
+      "licenseId": "CC-BY-NC-ND-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-4.0.json",
+      "referenceNumber": 351,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
+      "licenseId": "CC-BY-NC-SA-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-ND-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-4.0.json",
+      "referenceNumber": 328,
+      "name": "Creative Commons Attribution No Derivatives 4.0 International",
+      "licenseId": "CC-BY-ND-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nd/4.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-4.0.json",
+      "referenceNumber": 155,
+      "name": "Creative Commons Attribution Share Alike 4.0 International",
+      "licenseId": "CC-BY-SA-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/4.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC0-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC0-1.0.json",
+      "referenceNumber": 70,
+      "name": "Creative Commons Zero v1.0 Universal",
+      "licenseId": "CC0-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-only.json",
+      "referenceNumber": 133,
+      "name": "GNU General Public License v3.0 only",
+      "licenseId": "GPL-3.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-or-later.json",
+      "referenceNumber": 390,
+      "name": "GNU General Public License v3.0 or later",
+      "licenseId": "GPL-3.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-3.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-3.0-only.json",
+      "referenceNumber": 3,
+      "name": "GNU Lesser General Public License v3.0 only",
+      "licenseId": "LGPL-3.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
+        "https://opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-3.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-3.0-or-later.json",
+      "referenceNumber": 262,
+      "name": "GNU Lesser General Public License v3.0 or later",
+      "licenseId": "LGPL-3.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
+        "https://opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT.json",
+      "referenceNumber": 608,
+      "name": "MIT License",
+      "licenseId": "MIT",
+      "seeAlso": [
+        "https://opensource.org/license/mit/"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/MPL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MPL-2.0.json",
+      "referenceNumber": 263,
+      "name": "Mozilla Public License 2.0",
+      "licenseId": "MPL-2.0",
+      "seeAlso": [
+        "https://www.mozilla.org/MPL/2.0/",
+        "https://opensource.org/licenses/MPL-2.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.json",
+      "referenceNumber": 455,
+      "name": "Mozilla Public License 2.0 (no copyleft exception)",
+      "licenseId": "MPL-2.0-no-copyleft-exception",
+      "seeAlso": [
+        "https://www.mozilla.org/MPL/2.0/",
+        "https://opensource.org/licenses/MPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OSL-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OSL-3.0.json",
+      "referenceNumber": 300,
+      "name": "Open Software License 3.0",
+      "licenseId": "OSL-3.0",
+      "seeAlso": [
+        "https://web.archive.org/web/20120101081418/http://rosenlaw.com:80/OSL3.0.htm",
+        "https://opensource.org/licenses/OSL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Unlicense.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Unlicense.json",
+      "referenceNumber": 411,
+      "name": "The Unlicense",
+      "licenseId": "Unlicense",
+      "seeAlso": [
+        "https://unlicense.org/"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    }
+  ]
+}

--- a/test/test_data/valid_crate/ro-crate-metadata.json
+++ b/test/test_data/valid_crate/ro-crate-metadata.json
@@ -22,11 +22,10 @@
             "datePublished": "2024-03-08",
             "publisher": "https://ror.org/0abcdef00",
             "license": {
-                "@id": "http://spdx.org/licenses/CC0-1.0",
+                "@id": "https://spdx.org/licenses/CC-BY-NC-SA-4.0.html",
                 "@type": "CreativeWork",
-                "name": "CC0-1.0",
-                "description": "Creative Commons Zero v1.0 Universal",
-                "url": "https://creativecommons.org/publicdomain/zero/1.0/"
+                "name": "CC BY-NC-SA 4.0 International",
+                "description": "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International"
             },
             "author": {
                 "@id": "https://orcid.org/0000-0000-0000-0000"

--- a/test/test_licenses.py
+++ b/test/test_licenses.py
@@ -1,30 +1,11 @@
-from unittest import TestCase
-
 import json
-import requests
 import pytest
 
-from rocrate.model.person import Person
-from rocrate.rocrate import ROCrate, ContextEntity
+from rocrate.rocrate import ContextEntity
 
 from rocrate_upload.upload import (
-    build_zenodo_creator_list,
-    build_zenodo_metadata_from_crate,
     get_license,
 )
-
-SPDX_LICENSES = requests.get(
-    "https://raw.githubusercontent.com/spdx/license-list-data/main/json/licenses.json"
-).json()["licenses"]
-
-ZENODO_LICENSES = requests.get(
-    "https://raw.githubusercontent.com/zenodo/zenodo-rdm/e477db5dad2c35edd3e6549c8725e1d67fab4ba2/app_data/vocabularies/licenses.csv",
-).content
-ZENODO_LICENSES = str(ZENODO_LICENSES)
-
-SPDX_LICENSES_IN_ZENODO = [
-    l for l in SPDX_LICENSES if f'{l["licenseId"].lower()},' in ZENODO_LICENSES
-]
 
 with open("test/test_data/licenses.json") as licenses_file:
     LICENSES_TO_TEST = json.load(licenses_file)["licenses"]

--- a/test/test_licenses.py
+++ b/test/test_licenses.py
@@ -48,36 +48,20 @@ def test_get_license_from_spdx_reference(license):
     "license",
     LICENSES_TO_TEST,
 )
-def test_get_license_from_spdx_name(license):
+def test_get_license_fails_with_non_spdx_string(license):
     # Arrange
     name = license["name"]
 
     # Act & Assert
-    res = get_license(name)
-    assert res == name
+    with pytest.raises(ValueError):
+        res = get_license(name)
 
 
 @pytest.mark.parametrize(
     "license",
     LICENSES_TO_TEST,
 )
-def test_get_license_from_urls(license):
-    # Arrange
-    urls = license["seeAlso"]
-
-    # Act
-    res = [get_license(url) for url in urls]
-
-    # Assert
-    for r, u in zip(res, urls):
-        assert r == u
-
-
-@pytest.mark.parametrize(
-    "license",
-    LICENSES_TO_TEST,
-)
-def test_get_license_from_entity__id_spdx_uri(license):
+def test_get_license_from_entity(license):
     # Arrange
     entity = ContextEntity(
         None, license["reference"], properties={"name": license["name"]}
@@ -94,75 +78,13 @@ def test_get_license_from_entity__id_spdx_uri(license):
     "license",
     LICENSES_TO_TEST,
 )
-def test_get_license_from_entity__id_spdx_id(license):
+def test_get_license_from_entity_fails_if_no_spdx_uri(license):
     """Just the SPDX id will not be used - as creates false positives with local ids"""
     # Arrange
     entity = ContextEntity(
         None, license["licenseId"], properties={"name": license["name"]}
     )
 
-    # Act
-    res = get_license(entity)
-
-    # Assert
-    assert res == license["name"]
-
-
-@pytest.mark.parametrize(
-    "license",
-    LICENSES_TO_TEST,
-)
-def test_get_license_from_entity__id_name(license):
-    # Arrange
-    entity = ContextEntity(None, license["name"])
-
-    # Act
-    res = get_license(entity)
-
-    # Assert
-    assert res == license["name"]
-
-
-@pytest.mark.parametrize(
-    "license",
-    LICENSES_TO_TEST,
-)
-def test_get_license_from_entity__id_url(license):
-    # Arrange
-    entity = ContextEntity(None, license["seeAlso"][0])
-
-    # Act
-    res = get_license(entity)
-
-    # Assert
-    assert res == license["seeAlso"][0]
-
-
-@pytest.mark.parametrize(
-    "license",
-    LICENSES_TO_TEST,
-)
-def test_get_license_from_entity__id_local(license):
-    # Arrange
-    entity = ContextEntity(None, "#local_id", properties={"name": license["name"]})
-
-    # Act
-    res = get_license(entity)
-
-    # Assert
-    assert res == license["name"]
-
-
-@pytest.mark.parametrize(
-    "license",
-    LICENSES_TO_TEST,
-)
-def test_get_license_from_entity__id_local_no_name(license):
-    # Arrange
-    entity = ContextEntity(None, "#local_id")
-
-    # Act
-    res = get_license(entity)
-
-    # Assert
-    assert res == "local_id"
+    # Act & Assert
+    with pytest.raises(ValueError):
+        res = get_license(entity)

--- a/test/test_licenses.py
+++ b/test/test_licenses.py
@@ -16,27 +16,37 @@ SPDX_LICENSES = requests.get(
     "https://raw.githubusercontent.com/spdx/license-list-data/main/json/licenses.json"
 ).json()["licenses"]
 
+ZENODO_LICENSES = requests.get(
+    "https://raw.githubusercontent.com/zenodo/zenodo-rdm/e477db5dad2c35edd3e6549c8725e1d67fab4ba2/app_data/vocabularies/licenses.csv",
+).content
+ZENODO_LICENSES = str(ZENODO_LICENSES)
+
+SPDX_LICENSES_IN_ZENODO = [
+    l for l in SPDX_LICENSES if f'{l["licenseId"].lower()},' in ZENODO_LICENSES
+]
+print(SPDX_LICENSES_IN_ZENODO)
+
 
 @pytest.mark.parametrize(
     "license",
-    SPDX_LICENSES[:10],
+    SPDX_LICENSES_IN_ZENODO,
 )
 def test_get_license_from_spdx_reference(license):
     # Arrange
+    print(len(SPDX_LICENSES_IN_ZENODO))
+
     id = license["licenseId"].lower()
     print(id)
     reference = license["reference"]
 
-    # Act
+    # Act & Assert
     res = get_license(reference)
-
-    # Assert
-    assert res == id or None
+    assert res == id
 
 
 @pytest.mark.parametrize(
     "license",
-    SPDX_LICENSES[:10],
+    SPDX_LICENSES_IN_ZENODO,
 )
 def test_get_license_from_spdx_name(license):
     # Arrange
@@ -44,10 +54,8 @@ def test_get_license_from_spdx_name(license):
     print(id)
     name = license["name"]
 
-    # Act
+    # Act & Assert
     res = get_license(name)
-
-    # Assert
     assert res == id
 
 

--- a/test/test_licenses.py
+++ b/test/test_licenses.py
@@ -1,0 +1,69 @@
+from unittest import TestCase
+
+import requests
+import pytest
+
+from rocrate.model.person import Person
+from rocrate.rocrate import ROCrate
+
+from rocrate_upload.upload import (
+    build_zenodo_creator_list,
+    build_zenodo_metadata_from_crate,
+    get_license,
+)
+
+SPDX_LICENSES = requests.get(
+    "https://raw.githubusercontent.com/spdx/license-list-data/main/json/licenses.json"
+).json()["licenses"]
+
+
+@pytest.mark.parametrize(
+    "license",
+    SPDX_LICENSES[:10],
+)
+def test_get_license_from_spdx_reference(license):
+    # Arrange
+    id = license["licenseId"].lower()
+    print(id)
+    reference = license["reference"]
+
+    # Act
+    res = get_license(reference)
+
+    # Assert
+    assert res == id or None
+
+
+@pytest.mark.parametrize(
+    "license",
+    SPDX_LICENSES[:10],
+)
+def test_get_license_from_spdx_name(license):
+    # Arrange
+    id = license["licenseId"].lower()
+    print(id)
+    name = license["name"]
+
+    # Act
+    res = get_license(name)
+
+    # Assert
+    assert res == id
+
+
+# @pytest.mark.parametrize(
+#     "license",
+#     LICENSES[:5],
+# )
+# def test_get_license_from_urls(license):
+#     # Arrange
+#     id = license["licenseId"].lower()
+#     print(id)
+#     urls = license["seeAlso"]
+
+#     # Act
+#     res = [get_license(url) for url in urls]
+
+#     # Assert
+#     for r in res:
+#         assert r == id

--- a/test/test_licenses.py
+++ b/test/test_licenses.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+import json
 import requests
 import pytest
 
@@ -24,16 +25,18 @@ ZENODO_LICENSES = str(ZENODO_LICENSES)
 SPDX_LICENSES_IN_ZENODO = [
     l for l in SPDX_LICENSES if f'{l["licenseId"].lower()},' in ZENODO_LICENSES
 ]
-print(SPDX_LICENSES_IN_ZENODO)
+
+with open("test/test_data/licenses.json") as licenses_file:
+    LICENSES_TO_TEST = json.load(licenses_file)["licenses"]
 
 
 @pytest.mark.parametrize(
     "license",
-    SPDX_LICENSES_IN_ZENODO,
+    LICENSES_TO_TEST,
 )
 def test_get_license_from_spdx_reference(license):
     # Arrange
-    print(len(SPDX_LICENSES_IN_ZENODO))
+    print(len(LICENSES_TO_TEST))
 
     id = license["licenseId"].lower()
     print(id)
@@ -46,7 +49,7 @@ def test_get_license_from_spdx_reference(license):
 
 @pytest.mark.parametrize(
     "license",
-    SPDX_LICENSES_IN_ZENODO,
+    LICENSES_TO_TEST,
 )
 def test_get_license_from_spdx_name(license):
     # Arrange
@@ -59,19 +62,19 @@ def test_get_license_from_spdx_name(license):
     assert res == id
 
 
-# @pytest.mark.parametrize(
-#     "license",
-#     LICENSES[:5],
-# )
-# def test_get_license_from_urls(license):
-#     # Arrange
-#     id = license["licenseId"].lower()
-#     print(id)
-#     urls = license["seeAlso"]
+@pytest.mark.parametrize(
+    "license",
+    LICENSES_TO_TEST,
+)
+def test_get_license_from_urls(license):
+    # Arrange
+    id = license["licenseId"].lower()
+    print(id)
+    urls = license["seeAlso"]
 
-#     # Act
-#     res = [get_license(url) for url in urls]
+    # Act
+    res = [get_license(url) for url in urls]
 
-#     # Assert
-#     for r in res:
-#         assert r == id
+    # Assert
+    for r in res:
+        assert r == id

--- a/test/test_upload.py
+++ b/test/test_upload.py
@@ -27,6 +27,7 @@ class TestUpload(TestCase):
                     "gnd": None,
                 }
             ],
+            "license": "cc-by-nc-sa-4.0",
         }
 
         # Act


### PR DESCRIPTION
Adds _limited_ preservation of license to the Zenodo metadata.

Notes:
- legacy Zenodo API accepts only an `id` for the license, which is the same as the license's SPDX identifier, but lowercase.
- you can search the Zenodo license list using id, name, URLs, etc, but this is very unreliable if there are multiple licenses with similar names/ids. I tried to implement this, but I couldn't get the number of false matches down far enough for some of the common licenses.
- due to these limitations, the code will only be able to set the license if the RO-Crate license `@id` is the SPDX URI for that license. Other URIs, names, etc. will not work.

#5 