### PR TITLE
Handle case where RDE has no author

### DIFF
--- a/src/rocrate_zenodo/upload.py
+++ b/src/rocrate_zenodo/upload.py
@@ -24,7 +24,7 @@ def build_zenodo_metadata_from_crate(crate: ROCrate) -> Metadata:
     """Given an RO-Crate, collect the metadata to use in Zenodo upload"""
     # retrieve author(s)
     authors = crate.root_dataset.get("author")
-    creators = build_zenodo_creator_list(authors)
+    creators = build_zenodo_creator_list(authors) if authors else []
 
     # retrieve title
     title = crate.root_dataset.get("name")

--- a/test/test_data/no_author_crate/ro-crate-metadata.json
+++ b/test/test_data/no_author_crate/ro-crate-metadata.json
@@ -1,0 +1,38 @@
+{
+    "@context": "https://w3id.org/ro/crate/1.1/context",
+    "@graph": [
+        {
+            "@id": "ro-crate-metadata.json",
+            "@type": "CreativeWork",
+            "conformsTo": {
+                "@id": "https://w3id.org/ro/crate/1.1"
+            },
+            "about": {
+                "@id": "./"
+            }
+        },
+        {
+            "@id": "./",
+            "@type": [
+                "Dataset",
+                "LearningResource"
+            ],
+            "name": "Demo Crate",
+            "description": "a demo crate for Galaxy training",
+            "datePublished": "2024-03-08",
+            "publisher": "https://ror.org/0abcdef00",
+            "license": {
+                "@id": "https://spdx.org/licenses/CC-BY-NC-SA-4.0.html",
+                "@type": "CreativeWork",
+                "name": "CC BY-NC-SA 4.0 International",
+                "description": "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International"
+            }
+        },
+        {
+            "@id": "https://ror.org/0abcdef00",
+            "@type": "Organization",
+            "name": "Example University",
+            "url": "https://www.example.org"
+        }
+    ]
+}

--- a/test/test_upload.py
+++ b/test/test_upload.py
@@ -36,6 +36,27 @@ class TestUpload(TestCase):
         # Assert
         self.assertDictEqual(expected, result_select)
 
+    def test_build_zenodo_metadata__no_author(self):
+        # Arrange
+        crate_path = "test/test_data/no_author_crate"
+        crate = ROCrate(crate_path)
+
+        expected = {
+            "title": "Demo Crate",
+            "upload_type": "dataset",
+            "description": "a demo crate for Galaxy training",
+            "creators": [],
+            "license": "cc-by-nc-sa-4.0",
+        }
+
+        # Act
+        result = build_zenodo_metadata_from_crate(crate)
+        result = result.model_dump()
+        result_select = {key: result[key] for key in result if key in expected}
+
+        # Assert
+        self.assertDictEqual(expected, result_select)
+
     def test_build_zenodo_metadata_fails_with_invalid_data(self):
         # Arrange
         crate_path = "test/test_data/invalid_data_crate"


### PR DESCRIPTION
Fixes bug reported by @alexhambley where `get_author_details()` errors if the input is `None` (i.e. if the root data entity does not have `author` set).
